### PR TITLE
Dev - GTM implementation 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,21 @@
+.DS_Store
+node_modules/
+/dist/
+
+# local env files
+.env.local
+.env.*.local
+
+# Log files
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Editor directories and files
+.idea
+.vscode
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw*

--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
     "storage-helper": "^1.4.1",
     "vercel": "^20.0.0",
     "vue": "^2.6.11",
-    "vue-analytics": "^5.22.1",
     "vue-material-design-icons": "^4.4.0",
     "vue-router": "^3.1.5",
+    "vue-tag-manager": "^0.1.2",
     "vuelidate": "^0.7.5",
     "vuetify": "^2.2.14",
     "vuex": "^3.5.1"

--- a/public/index.html
+++ b/public/index.html
@@ -28,26 +28,10 @@
   <meta name="Description" content="The Tech for Good talent partner.">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@mdi/font@latest/css/materialdesignicons.min.css">
     <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;700&display=swap" rel="stylesheet">
-<script type="text/javascript">
-  window.heap = window.heap || [], heap.load = function (e, t) { window.heap.appid = e, window.heap.config = t = t || {}; var r = document.createElement("script"); r.type = "text/javascript", r.async = !0, r.src = "https://cdn.heapanalytics.com/js/heap-" + e + ".js"; var a = document.getElementsByTagName("script")[0]; a.parentNode.insertBefore(r, a); for (var n = function (e) { return function () { heap.push([e].concat(Array.prototype.slice.call(arguments, 0))) } }, p = ["addEventProperties", "addUserProperties", "clearEventProperties", "identify", "resetIdentity", "removeEventProperty", "setEventProperties", "track", "unsetEventProperty"], o = 0; o < p.length; o++)heap[p[o]] = n(p[o]) };
-  heap.load("2590093425"); 
-</script>
-<!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-PH3Y6TK0PQ"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag() { dataLayer.push(arguments); }
-  gtag('js', new Date());
 
-  gtag('config', 'G-PH3Y6TK0PQ');
-</script>
 </head>
 
 <body data-instant-intensity="viewport-all">
-  <!-- Google Tag Manager (noscript) -->
-  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WRTNCTN" height="0" width="0"
-      style="display:none;visibility:hidden"></iframe></noscript>
-  <!-- End Google Tag Manager (noscript) -->
   <center>
     <noscript>
       <strong>I'm sorry but Confido doesn't work properly without JavaScript enabled.
@@ -60,7 +44,6 @@
   <script src="//instant.page/3.0.0" type="module" defer
     integrity="sha384-OeDn4XE77tdHo8pGtE1apMPmAipjoxUQ++eeJa6EtJCfHlvijigWiJpD7VDPWXV1">
   </script>
-  <!-- Global site tag (gtag.js) - Google Analytics -->
 </body>
 
 </html>

--- a/src/main.js
+++ b/src/main.js
@@ -1,23 +1,32 @@
 import Vue from 'vue';
 import App from './App.vue';
 import vuetify from './plugins/vuetify';
-import VueAnalytics from 'vue-ua';
+// import VueAnalytics from 'vue-ua';
+import VueTagManager from "vue-tag-manager"
+
+
 import router from './router';
 import './registerServiceWorker';
 import 'vue-material-design-icons/styles.css';
 
+
 Vue.config.productionTip = false;
 
-Vue.use(VueAnalytics, {
-  // [Required] The name of your app as specified in Google Analytics.
-  appName: 'Confido (new)',
-  // [Required] The version of your app.
-  appVersion: '1.0',
-  // [Required] Your Google Analytics tracking ID.
-  trackingId: 'G-PH3Y6TK0PQ',
-  // If you're using vue-router, pass the router instance here.
-  vueRouter: router,
-});
+// Vue.use(VueAnalytics, {
+//   // [Required] The name of your app as specified in Google Analytics.
+//   appName: 'Confido (new)',
+//   // [Required] The version of your app.
+//   appVersion: '1.0',
+//   // [Required] Your Google Analytics tracking ID.
+//   trackingId: 'GTM-M5TFCP2',
+//   // If you're using vue-router, pass the router instance here.
+//   vueRouter: router,
+// });
+
+// Install VUE GTM -> this will handle all analytics and marketing tags
+Vue.use(VueTagManager, {
+  gtmId: 'GTM-M5TFCP2'
+})
 
 new Vue({
   vuetify,

--- a/yarn.lock
+++ b/yarn.lock
@@ -12744,11 +12744,6 @@ vscode-uri@^1.0.6:
   resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-1.0.8.tgz#9769aaececae4026fb6e22359cb38946580ded59"
   integrity sha512-obtSWTlbJ+a+TFRYGaUumtVwb+InIUVI0Lu0VBUAPmj2cU5JutEXg3xUE0c2J5Tcy7h2DEKVJBFi+Y9ZSFzzPQ==
 
-vue-analytics@^5.22.1:
-  version "5.22.1"
-  resolved "https://registry.yarnpkg.com/vue-analytics/-/vue-analytics-5.22.1.tgz#9d6b32da56daee1b9dfb23a267b50349a03f710f"
-  integrity sha512-HPKQMN7gfcUqS5SxoO0VxqLRRSPkG1H1FqglsHccz6BatBatNtm/Vyy8brApktZxNCfnAkrSVDpxg3/FNDeOgQ==
-
 vue-cli-plugin-apollo@^0.21.3:
   version "0.21.3"
   resolved "https://registry.yarnpkg.com/vue-cli-plugin-apollo/-/vue-cli-plugin-apollo-0.21.3.tgz#520d336db0e88b26fe854833a555e2e29fe26571"
@@ -12852,6 +12847,11 @@ vue-style-loader@^4.1.0, vue-style-loader@^4.1.2:
   dependencies:
     hash-sum "^1.0.2"
     loader-utils "^1.0.2"
+
+vue-tag-manager@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/vue-tag-manager/-/vue-tag-manager-0.1.2.tgz#9602f944118a4fc849c1cff80aa3f57439685994"
+  integrity sha512-w1dKcPiBSpVZfsjyL+wdjjBjB1KWWnDjOQuKvbDa7JXjUDB5gOoD3fp2w4zRYCW0Ia5VW/k8ZFWMC+6Ldn/3YA==
 
 vue-template-compiler@^2.6.11:
   version "2.6.12"


### PR DESCRIPTION
Remove old Google Analytics/Heap UA implementation as it does not track SPA sufficiently.

Add vue-tag-manager to install GTM, so all analytics tags can be implemented via this method.

Also Add .gitignore file for ease of use.